### PR TITLE
Data 785 filter raygun environment variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,3 +6,7 @@ Version 0.0.1 (2018-06-24)
 
 * Initial release of ckanext-raygun, adds error handling middleware to the CKAN wsgi app
 
+Version 0.1.0 (2020-04-07)
+--------------------------
+
+* Added ability to pass RaygunSender config options. See https://github.com/MindscapeHQ/raygun4py#initialization-options for more information

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-=============
+==============
 ckanext-raygun
-=============
+==============
 
 A plugin for capturing exceptions using the [raygun](https://raygun.com) service.
 
@@ -40,10 +40,12 @@ To install ckanext-raygun:
 ---------------
 Config Settings
 ---------------
-Configuration of this plugin happens through standard python logging config and via a wsgi specific middleware that picks up the `ckanext.raygun_api_key` config field::
+Configuration of this plugin happens through standard python logging config and via a wsgi specific middleware that picks up the `ckanext.raygun.api_key` config field::
 
     # The api key for accessing raygun
     ckanext.raygun.api_key = <your_api_key_here>
+    # Optionally, set RaygunSender config (see raygun4py README for more info)
+    ckanext.raygun.sender_config = {}
 
     # To support ad-hoc paster commands reporting to raygun add the following handler to your log config
 
@@ -55,11 +57,10 @@ Configuration of this plugin happens through standard python logging config and 
     level = WARNING
     handlers = console, raygun
 
-
     # 2. configure a handler for raygun
     [handler_raygun]
-    class = raygun4py.raygunprovider.RaygunHandler
-    args = ("<your_api_key_here>",)
+    class = ckanext.raygun.plugin.RaygunHandler
+    args = ('<your_api_key_here>', <raygun_sender_config>,)
     level = NOTSET
     formatter = generic
 

--- a/ckanext/raygun/plugin.py
+++ b/ckanext/raygun/plugin.py
@@ -3,6 +3,7 @@ import logging
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from raygun4py.middleware import wsgi
+from raygun4py.raygunprovider import RaygunSender
 
 log = logging.getLogger(__name__)
 
@@ -51,4 +52,22 @@ class RaygunPlugin(plugins.SingletonPlugin):
 
     def get_api_key(self):
         return self.api_key
-    
+
+
+# Taken from https://github.com/MindscapeHQ/raygun4py/blob/f65727a8cc8c6e4b089a68efcd906d6dd7080568/python2/raygun4py/raygunprovider.py#L178
+# and modified to accept arguments to RaygunSender
+class RaygunHandler(logging.Handler):
+    def __init__(self, api_key, config, version=None):
+        logging.Handler.__init__(self)
+        print('Raygun logging handler initialised')
+        print('API key: {}'.format(api_key))
+        print('config dict: {}'.format(config))
+        self.sender = RaygunSender(api_key, config=config)
+        self.version = version
+
+    def emit(self, record):
+        userCustomData = {
+            "Logger Message": record.msg
+        }
+        self.sender.send_exception(userCustomData=userCustomData)
+

--- a/ckanext/raygun/plugin.py
+++ b/ckanext/raygun/plugin.py
@@ -6,7 +6,7 @@ from raygun4py.middleware import wsgi
 from raygun4py.raygunprovider import RaygunSender
 
 log = logging.getLogger(__name__)
-no_key_warning = 'ckanext.raygun.api_key is not defined in {} {}'
+no_key_warning = 'ckanext.raygun.api_key is not defined in config: {} {}'
 
 api_key_name = 'ckanext.raygun.api_key'
 sender_config_name = 'ckanext.raygun.sender_config'
@@ -21,10 +21,13 @@ class RaygunPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.ITemplateHelpers)
     api_key = ''
     sender_config = None
+    has_warned = False
 
     def _set_config(self, config, method_name):
         if api_key_name not in config:
-            log.warning(no_key_warning.format('RaygunPlugin', method_name))
+            if not self.has_warned:
+                log.warning(no_key_warning.format('RaygunPlugin', method_name))
+                self.has_warned = True
             return
 
         self.api_key = config.get(api_key_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-git+https://github.com/mediasuitenz/raygun4py#egg=raygun4py
-
+raygun4py>=4.0,<=5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-raygun4py>=4.0,<=5.0
+git+https://github.com/mediasuitenz/raygun4py@add_config_to_middleware#egg=raygun4py

--- a/setup.py
+++ b/setup.py
@@ -15,17 +15,17 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.0.1',
+    version='0.1.0',
 
     description='''Capture errors using raygun!''',
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/mediasuite/ckanext-raygun',
+    url='https://github.com/data-govt-nz/ckanext-raygun',
 
     # Author details
     author='''Media Suite''',
-    author_email='''ersin@mediasuite.co.nz''',
+    author_email='''mark@mediasuite.co.nz''',
 
     # Choose your license
     license='AGPL',


### PR DESCRIPTION
This PR extends the capabilities of the raygun plugin, allowing for RaygunSender config to be passed in to allow the consumer to modify the information sent to Raygun.

See https://github.com/MindscapeHQ/raygun4py#initialization-options for more info.