### PR TITLE
Fix template path broken as part of previous ckan 2.9 upgrade PR.

### DIFF
--- a/ckanext/raygun/plugin/__init__.py
+++ b/ckanext/raygun/plugin/__init__.py
@@ -59,7 +59,7 @@ class RaygunPlugin(plugins.SingletonPlugin):
         See IConfigurer.
         '''
         self._set_config(config, 'update_config')
-        toolkit.add_template_directory(config, 'templates')
+        toolkit.add_template_directory(config, '../templates')
 
     def get_helpers(self):
         '''Return the CKAN 2.0 template helper functions this plugin provides.


### PR DESCRIPTION
Previous PR (#3) for 2.9 compatibility broke the template path. This change fixes it. 